### PR TITLE
Fixes integration test so that plugin properly executes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ buildNumber.properties
 .mvn/timing.properties
 .idea
 *.iml
+*.classpath
+*.project
+*.settings

--- a/pitest-junit-5-plugin-test/src/test/java/net/cyphoria/pitest/junit5/JUnit5IntegrationTest.java
+++ b/pitest-junit-5-plugin-test/src/test/java/net/cyphoria/pitest/junit5/JUnit5IntegrationTest.java
@@ -58,10 +58,24 @@ class JUnit5IntegrationTest {
     void mutatestSimpleCodeEndExecutesTest() throws IOException, VerificationException {
         prepare("/simple");
 
+        verifier.executeGoal("test");
         verifier.executeGoal("org.pitest:pitest-maven:mutationCoverage");
 
-        verifier.verifyTextInLog("Ran 1 tests");
-        verifier.verifyTextInLog("Generated 1 mutations Killed 1");
+
+        verifier.verifyTextInLog("Generated 4 mutations Killed 2");
+
+
+        // At most we ought to run 8 tests (possibly less not looked at what the tests are doing)
+        verifier.verifyTextInLog("Ran 8 tests");
+
+        // This is what we actually observe
+        // verifier.verifyTextInLog("Ran 9 tests");
+        
+        // Investigation needed here. 
+        // Two possible explainations for the observed behaviour
+        // 1. Something isn't quite right with the test targetting in pitest (unrelated to this plugin)
+        // 2. This plugin is detecting more than 2 tests in the ProductionCodeTest test class.
+         
     }
 
 

--- a/pitest-junit-5-plugin-test/src/test/resources/simple/pom.xml
+++ b/pitest-junit-5-plugin-test/src/test/resources/simple/pom.xml
@@ -66,9 +66,10 @@
                     </targetClasses>
                     <failWhenNoMutations>false</failWhenNoMutations>
                     <verbose>true</verbose>
-                    <jvmArgs>
+                    <!-- <jvmArgs>
                         <jvmArg>-agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=y</jvmArg>
                     </jvmArgs>
+                    -->
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/pitest-junit-5-plugin-test/src/test/resources/simple/src/test/java/org/example/ProductionCodeTest.java
+++ b/pitest-junit-5-plugin-test/src/test/resources/simple/src/test/java/org/example/ProductionCodeTest.java
@@ -15,6 +15,8 @@
 package org.example;
 
 import org.junit.gen5.api.Test;
+import static org.junit.gen5.api.Assertions.*;
+
 
 /**
  *


### PR DESCRIPTION
This fixes the integration test so that it properly exercises the plugin, but fails.

The plugin looks to be largely working. The test is failing as pitest seems to be running 1 more test than the logical maximum.

This may be due to an issue in the junit-5 plugin, but it is also possible that the test has revealed an existing issue in the pitest targetting system.
